### PR TITLE
Usersテーブルにnicknameカラムの追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,15 @@
 class ApplicationController < ActionController::Base
+  #クロスサイトリクエストフォージェリ (CSRF)への対応策のコード
+  protect_from_forgery with: :exception
+
   before_action :authenticate_user!
+  #deviseコントローラーを使用するときにのみ処理をする
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:nickname])
+  endend
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :name,presence: true, length: {maximum: 20}
 end

--- a/db/migrate/20210902095226_add_nickname.rb
+++ b/db/migrate/20210902095226_add_nickname.rb
@@ -1,0 +1,5 @@
+class AddNickname < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :nickname, :string, null: false, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_30_141531) do
+ActiveRecord::Schema.define(version: 2021_09_02_095226) do
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2021_08_30_141531) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "nickname", default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
### what
・rails g migration クラス名 カラム名 にてusersテーブルにnicknameカラムを追加した
・applicationsコントローラーにstrongパラメーターを記述した
・user.rbに最大文字数20文字のバリデーションを追加した

### why
・ユーザー登録時にnicknameを登録させるため