### PR TITLE
カード編集機能の実装

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -17,6 +17,19 @@ class CardsController < ApplicationController
     @card = Card.find_by(id: params[:id])
   end
 
+  def edit
+    @card = Caid.find_by(id: params[:id])
+  end
+
+  def update
+    @card = Card.find_by(id: params[:id])
+    if @card.update_attributes(card_params)
+      redirect_to :root
+    else
+      render action :edit
+    end
+  end
+
   private
     def card_params
       params.require(:card).permit(:title, :memo, :list_id)

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,4 +1,6 @@
 class CardsController < ApplicationController
+  before_action :set_card, only:[:show, :edit, :update]
+
   def new
     @card = Card.new
     @list = List.find_by(id: params[:list_id])
@@ -14,15 +16,12 @@ class CardsController < ApplicationController
   end
 
   def show
-    @card = Card.find_by(id: params[:id])
   end
 
   def edit
-    @card = Caid.find_by(id: params[:id])
   end
 
   def update
-    @card = Card.find_by(id: params[:id])
     if @card.update_attributes(card_params)
       redirect_to :root
     else
@@ -33,5 +32,9 @@ class CardsController < ApplicationController
   private
     def card_params
       params.require(:card).permit(:title, :memo, :list_id)
+    end
+
+    def set_card
+      @card = Card.find_by(id: params[:id])
     end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -2,4 +2,5 @@
 @import 'custom';
 @import 'card/new.scss';
 @import 'card/show.scss';
+@import 'card/edit.scss';
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';

--- a/app/javascript/stylesheets/card/edit.scss
+++ b/app/javascript/stylesheets/card/edit.scss
@@ -1,0 +1,9 @@
+.cardeditPgae {
+  .cardeditForm {
+    max-width: 500px;
+    margin: 70px auto 0;
+    &_title, &_memo {
+      margin-bottom: 30px;
+    }
+  }
+}

--- a/app/javascript/stylesheets/card/show.scss
+++ b/app/javascript/stylesheets/card/show.scss
@@ -11,5 +11,27 @@
       border-bottom: 1px solid #ccc;
       margin-bottom: 30px;
     }
+
+    &_btnArea {
+      margin-top: 40px;
+      text-align: center;
+      & > a {
+        display: block;
+        &.edit_btn {
+          max-width: 200px;
+          margin: 0 auto;
+          background: #026aa7;
+          padding: 7px;
+          border-radius: 10px;
+          color: #fff;
+          transition: opacity .5s;
+          text-decoration: none;
+          &:hover {
+            opacity: .7;
+          }
+        }
+      }
+    }
+    
   }
 }

--- a/app/views/cards/edit.html.erb
+++ b/app/views/cards/edit.html.erb
@@ -1,0 +1,18 @@
+<div class="cardeditPgae">
+  <div class='container'>
+    <%= form_with model: @card, url: { action: :update }, html: { class: 'cardeditForm' }, local: true do |f| %>
+      <% if @card.errors.any? %>
+        <p class="text-danger">タイトルは1～255文字以内で入力してください</p>
+      <% end %>
+      <div class="cardeditForm_title">
+        <%= f.label :title %>
+        <%= f.text_field :title, class: "form-control", placeholder: "カード名" %>
+      </div>
+      <div class="cardeditForm_memo">
+        <%= f.label :memo %>
+        <%= f.text_area :memo, class: "form-control", placeholder: "詳細" %>
+      </div>
+      <div class="text-center"><%= f.submit "更新する", class: "submitBtn" %></div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -13,6 +13,10 @@
         <div>リスト名</div>
         <div><%= @card.list.title %></div>
       </div>
+      
+      <div class="cardContents_btnArea">
+        <%= link_to '編集する', edit_list_card_path(@card.list, @card), class: "edit_btn" %>
+      </div>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
   
   root 'tops#index'
   resources :lists, only:[:new, :create, :edit, :update, :destroy] do
-    resources :cards, only:[:new, :create, :show]
+    resources :cards, only:[:new, :create, :show, :edit, :update]
   end
 end


### PR DESCRIPTION
### what
・ルーティングにてcardsコントローラのedit,updateアクションの追記
・cards_controllerにてedit,updateの定義
・cards_controllerにbefore_actionを設定し、同じコードを削除
・cardsビューの編集ページを作成
・cardsビューの詳細ページに編集ページへの遷移を追記
・scssの編集

### why
作成したcardの編集ができるようにするため